### PR TITLE
Add v0.11 - v0.14 release posts.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,9 @@ gem "jekyll", "~> 3"
 gem "jekyll-theme-open-project", "~> 2.0.22"
 # gem "jekyll-theme-open-project", path: "~/src/jekyll-theme-open-project"
 
+# Kramdown parser
+gem "kramdown-parser-gfm"
+
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem "jekyll-seo-tag"

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,6 @@ _site:
 	bundle exec jekyll build --trace
 
 serve:
-	bundle exec jekyll serve
+	bundle exec jekyll serve --trace
 
 .PHONY: bundle all open serve distclean clean

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: RNP
-description: C library approach to OpenPGP; GnuPG alternative.
+description: Email encryption with unrivaled performance, RFC&nbsp;4880 compliant.
 # The above two are used by jekyll-seo-tag for things such as
 # `<title>` and `<meta>` tags, as well as elsewhere by the theme.
 
@@ -8,10 +8,10 @@ algolia_search:
   index_name: 'rnpgp'
 
 tagline: >-
-  High-performance OpenPGP library in&nbsp;C++
+  Powering end-to-end email encryption in Mozilla Thunderbird.
 
 pitch: >-
-  Compatible GnuPG&nbsp;alternative, fully&nbsp;compliant to&nbsp;RFC&nbsp;4880.
+  Secure email with unrivaled performance. RFC&nbsp;4880 compliant.
 
 author: "Ribose Inc."
 

--- a/_posts/2018-08-20-rnp-010-released.adoc
+++ b/_posts/2018-08-20-rnp-010-released.adoc
@@ -1,6 +1,6 @@
 ---
 layout: post
-title:  "RNP 0.10.0 has been released"
+title:  "RNP 0.10.0 released"
 date:   2018-08-20 20:37:38 +0700
 categories: release
 excerpt: >-
@@ -16,7 +16,8 @@ redirect_from:
 
 Meet RNP, an  RFC4880-compliant OpenPGP library written in {cpp}.
 
-RNP was born at Hong Kong-based Ribose and is maintained under its initiative.
+RNP was born at Ribose and is continuously maintained under its initiative.
+
 Originally stemmed from NetPGP, it has little in common with its ancestor now
 after a year of development—after a clean-up of legacy code,
 corrected compatibility issues with GnuPG and other implementations,

--- a/_posts/2018-09-17-rnp-011-released.adoc
+++ b/_posts/2018-09-17-rnp-011-released.adoc
@@ -1,6 +1,6 @@
 ---
 layout: post
-title:  "RNP 0.11.0 has been released"
+title:  "RNP 0.11.0 released"
 date:   2018-09-17 19:05:38 +0700
 categories: release
 excerpt: >-
@@ -10,6 +10,8 @@ redirect_from:
 ---
 
 == General
+
+This update improves key import/merge operations and support for automating S2K iterations calculation.
 
 * Remove some old SSH key support.
 * Add support for dynamically calculating the S2K iterations.

--- a/_posts/2018-09-17-rnp-011-released.adoc
+++ b/_posts/2018-09-17-rnp-011-released.adoc
@@ -1,0 +1,21 @@
+---
+layout: post
+title:  "RNP 0.11.0 has been released"
+date:   2018-09-17 19:05:38 +0700
+categories: release
+excerpt: >-
+  This update improves key import/merge operations and support for automating S2K iterations calculation.
+redirect_from:
+  - /blog/17-09-2018/rnp-011-released/
+---
+
+== General
+
+* Remove some old SSH key support.
+* Add support for dynamically calculating the S2K iterations.
+* Add support for extracting the public key from the secret key.
+* Add support for merging information between keys.
+
+== CLI
+
+* Add options for custom S2K iterations/times (dynamic by default).

--- a/_posts/2019-01-14-rnp-012-released.adoc
+++ b/_posts/2019-01-14-rnp-012-released.adoc
@@ -1,31 +1,37 @@
 ---
 layout: post
-title:  "RNP 0.12.0 has been released"
+title:  "RNP 0.12.0 released"
 date:   2019-01-14 19:35:38 +0700
 categories: release
 excerpt: >-
-  Added support for extra ECC curves (Brainpool p256, p384, p512, secp256k1, x25519). Extended FFI with AEAD support and a bunch of examples. CLI functionality extended with -f command, allowing to use the key loaded from a file.
+  Added support for extra ECC curves (Brainpool p256, p384, p512, secp256k1, x25519). Extended FFI with AEAD support and a bunch of examples. CLI functionality extended with `-f` command, allowing to use the key loaded from a file.
 redirect_from:
   - /blog/14-01-2019/rnp-012-released/
 ---
 
 == General
 
+Added support for extra ECC curves (Brainpool p256, p384, p512, secp256k1, x25519).
+
+Extended FFI with AEAD support and a bunch of examples.
+
+CLI functionality extended with `-f` command, allowing to use the key loaded from a file.
+
 * We now require Botan 2.8+.
 * Fixed key grip calculations for various key types.
-* Fixed SM2 signatures hashing the hash of the message. See comment in issue #436.
+* Fixed SM2 signatures hashing the hash of the message. See comment in https://github.com/rnpgp/rnp/issues/436[issue #436].
 * Added support for G10 ECC keys.
 * Fixed dumping of partial-length packets.
 * Added support for extra ECC curves:
-  * Brainpool p256, p384, p512 ECDSA/ECDH
-  * secp256k1 ECDSA/ECDH
-  * x25519
+** Brainpool p256, p384, p512 ECDSA/ECDH
+** secp256k1 ECDSA/ECDH
+** x25519
 * Fixed AEAD with newer versions of Botan.
 * Removed a lot of legacy code.
 
 == CLI
 
-* rnp: Added -f/--keyfile option to load keys directly from a file.
+* rnp: Added `-f`/`--keyfile` option to load keys directly from a file.
 * rnp: Fixed issue with selecting G10 secret keys via userid.
 * rnpkeys: Added support for SM2 with arbitrary hashes.
 * redumper: Added -g option to dump fingerprints and grips.

--- a/_posts/2019-01-14-rnp-012-released.adoc
+++ b/_posts/2019-01-14-rnp-012-released.adoc
@@ -1,0 +1,39 @@
+---
+layout: post
+title:  "RNP 0.12.0 has been released"
+date:   2019-01-14 19:35:38 +0700
+categories: release
+excerpt: >-
+  Added support for extra ECC curves (Brainpool p256, p384, p512, secp256k1, x25519). Extended FFI with AEAD support and a bunch of examples. CLI functionality extended with -f command, allowing to use the key loaded from a file.
+redirect_from:
+  - /blog/14-01-2019/rnp-012-released/
+---
+
+== General
+
+* We now require Botan 2.8+.
+* Fixed key grip calculations for various key types.
+* Fixed SM2 signatures hashing the hash of the message. See comment in issue #436.
+* Added support for G10 ECC keys.
+* Fixed dumping of partial-length packets.
+* Added support for extra ECC curves:
+  * Brainpool p256, p384, p512 ECDSA/ECDH
+  * secp256k1 ECDSA/ECDH
+  * x25519
+* Fixed AEAD with newer versions of Botan.
+* Removed a lot of legacy code.
+
+== CLI
+
+* rnp: Added -f/--keyfile option to load keys directly from a file.
+* rnp: Fixed issue with selecting G10 secret keys via userid.
+* rnpkeys: Added support for SM2 with arbitrary hashes.
+* redumper: Added -g option to dump fingerprints and grips.
+* redumper: Display key id/fingerprint/grip in packet listings.
+
+== FFI
+
+* Added FFI examples.
+* Fixed a regression with loading subkeys directly.
+* Implemented support for per-signature hash and creation/expiration time.
+* Added AEAD support.

--- a/_posts/2020-01-03-rnp-013-released.adoc
+++ b/_posts/2020-01-03-rnp-013-released.adoc
@@ -1,6 +1,6 @@
 ---
 layout: post
-title:  "RNP 0.13.0 has been released"
+title:  "RNP 0.13.0 released"
 date:   2020-01-03 20:05:38 +0700
 categories: release
 excerpt: >-
@@ -10,6 +10,8 @@ redirect_from:
 ---
 
 == General
+
+Next version of the RNP library extends FFI and CLI interfaces, giving more flexibility and control to the user.
 
 * Fixed a double-free on invalid armor headers.
 * Fixed broken versioning when used as a git submodule.
@@ -22,8 +24,8 @@ redirect_from:
 
 == CLI
 
-* rnpkeys: Removed a few redundant commands (--get-key, --print-sigs, --trusted-keys, ...).
-* rnpkeys: Added --secret option.
+* rnpkeys: Removed a few redundant commands (`--get-key`, `--print-sigs`, `--trusted-keys`, ...).
+* rnpkeys: Added `--secret` option.
 * rnpkeys: Display 'ssb' for secret subkeys.
 * rnp: Added `--list-packets` parameters (`--json`, etc.).
 * rnp: Removed `--show-keys`.
@@ -61,5 +63,5 @@ redirect_from:
 
 == Packaging
 
-* RPM: Split packages into librnp0, librnp0-devel, and rnp0.
+* RPM: Split packages into `librnp0`, `librnp0-devel`, and `rnp0`.
 

--- a/_posts/2020-01-03-rnp-013-released.adoc
+++ b/_posts/2020-01-03-rnp-013-released.adoc
@@ -1,0 +1,65 @@
+---
+layout: post
+title:  "RNP 0.13.0 has been released"
+date:   2020-01-03 20:05:38 +0700
+categories: release
+excerpt: >-
+  Next version of the RNP library extends FFI and CLI interfaces, giving more flexibility and control to the user.
+redirect_from:
+  - /blog/03-01-2020/rnp-013-released/
+---
+
+== General
+
+* Fixed a double-free on invalid armor headers.
+* Fixed broken versioning when used as a git submodule.
+* Fixed an infinite loop on parsing truncated armored keys.
+* Fixed armored stream parsing to be more flexible and allow blank lines before trailer.
+* Fixed the armor header for detached signatures (previously MESSAGE, now SIGNATURE).
+* Improved setting of default qbits for DSA.
+* Fixed a crash when retrieving signature revocation reason.
+* Stop using expensive tests for key material validation.
+
+== CLI
+
+* rnpkeys: Removed a few redundant commands (--get-key, --print-sigs, --trusted-keys, ...).
+* rnpkeys: Added --secret option.
+* rnpkeys: Display 'ssb' for secret subkeys.
+* rnp: Added `--list-packets` parameters (`--json`, etc.).
+* rnp: Removed `--show-keys`.
+
+== FFI
+
+* Added `rnp_version_commit_timestamp` to retrieve the commit timestamp
+  (for non-release builds).
+* Added a new (non-JSON) key generation API (`rnp_op_generate_create` etc.).
+* Added `rnp_unload_keys` function to unload all keys.
+* Added `rnp_key_remove` to unload a single key.
+* Expanded bit length support for JSON key generation.
+* Added `rnp_key_get_subkey_count`/`rnp_key_get_subkey_at`.
+* Added various key property accessors (`rnp_key_get_bits`, `rnp_key_get_curve`).
+* Added `rnp_op_generate_set_protection_password`.
+* Added `rnp_key_packets_to_json`/`rnp_dump_packets_to_json`.
+* Added `rnp_key_get_creation`, `rnp_key_get_expiration`.
+* Added `rnp_key_get_uid_handle_at`, `rnp_uid_is_revoked`, etc.
+* Added `rnp_key_is_revoked` and related functions to check for revocation.
+* Added `rnp_output_to_path` and `rnp_output_finish`.
+* Added `rnp_import_keys`.
+* Added `rnp_calculate_iterations`.
+* Added `rnp_supports_feature`/`rnp_supported_features`.
+* Added `rnp_enable_debug`/`rnp_disable_debug`.
+* Added `rnp_key_get_primary_grip`.
+* Added `rnp_output_to_armor`.
+* Added `rnp_op_generate_set_request_password`.
+* Added `rnp_dump_packets_to_output`.
+* Added `rnp_output_write`.
+* Added `rnp_guess_contents`.
+* Implemented `rnp_op_set_file_name`/`rnp_op_set_file_mtime`.
+* Added `rnp_op_encrypt_set_aead_bits`.
+* Added `rnp_op_verify_signature_get_handle`.
+* Added `rnp_signature_packet_to_json`.
+
+== Packaging
+
+* RPM: Split packages into librnp0, librnp0-devel, and rnp0.
+

--- a/_posts/2021-01-21-rnp-014-released.adoc
+++ b/_posts/2021-01-21-rnp-014-released.adoc
@@ -1,0 +1,98 @@
+---
+layout: post
+title:  "RNP 0.14.0 has been released"
+date:   2021-01-21 21:05:38 +0700
+categories: release
+excerpt: >-
+  After a long delay the next version of the library and CLI was released. It a lot of major FFI, CLI and security improvements and compatibility fixes. Also now it can be built for Windows via MSVC and MinGW/MSYS2.
+redirect_from:
+  - /blog/21-01-2021/rnp-014-released/
+---
+
+== General
+
+* Improved key validation: require to have at least one valid, non-expiring self signature.
+* Added support for 'stripped' keys without userids and certifications but with valid subkey binding signature.
+* Added support for Windows via MinGW/MSYS2.
+* Added support for Windows via MSVC.
+* Fixed secret key locking when it is updated with new signatures/subkeys.
+* Fixed key expiry/flags calculation (take in account only the latest valid self-signature/subkey binding).
+* Fixed MDC reading if it appears on 8k boundary.
+* Disabled logging by default in release builds and added support for environment variable `RNP_LOG_CONSOLE` to enable it back.
+* Fixed leading zeroes for secp521r1 b & n field constants.
+* Allowed keys and signatures with invalid MPI bit count.
+* Added support for private/experimental signature subpackets, used by GnuPG and other implementations.
+* Added support for reserved/placeholder signatures.
+* Added support for zero-size userid/attr packet.
+* Relaxed packet dumping, ignoring invalid packets and allowing to find wrong packet easier.
+* Improved logging of errored keys/subkeys information for easier debugging.
+* Fixed support for old RSA sign-only/encrypt-only and ElGamal encrypt-and-sign keys.
+* Fixed support for ElGamal keys larger then 3072 bits.
+* Fixed symbol visibility so only FFI functions are exposed outside of the library.
+* Added support for unwrapping of raw literal packets.
+* Fixed crash with non-detached signature input, fed into the `rnp_op_verify_detached_create()`.
+* Significantly reduced memory usage for the keys large number of signatures.
+* Fixed long armor header lines processing.
+* Added basic support for GnuPG's offline primary keys (`gnupg --export-secret-subkeys`) and secret keys, stored on card.
+* Fixed primary key binding signature validation when hash algorithm differs from the one used in the subkey binding signature.
+* Fixed multiple memory leaks related to invalid algorithms/versions/etc.
+* Fixed possible crashes during processing of malformed armored input.
+* Limited allowed nesting levels for OpenPGP packets.
+* Fixed support for text-mode signatures.
+* Replaced strcpy calls with std::string and memcpy where applicable.
+* Removed usage of mktemp, replacing it with mkstemp.
+* Replaced usage of deprecated `botan_pbkdf()` with `botan_pwdhash()`.
+* Added support for the marker packet, issued by some implementations.
+* Added support for unknown experimental s2ks.
+* Fixed armored message contents detection (so armored revocation signature is not more reported as the public key).
+* Changed behaviour to use latest encryption subkey by default.
+* Fixed support for widechar parameters/file names on Windows.
+* Implemented userid validity checks so only certified/non-expired/non-revoked userid may be searched.
+* Fixed GnuPG compatibility issues with CR (`\r`) characters in text-mode and cleartext-signed documents.
+* Improved performance of the key/uid signatures access.
+* Migrated tests to the Python 3.
+* Migrated most of the internal code to C++.
+
+== CLI
+
+* Do not load keyring when it is not required, avoiding extra `keyring not found` output.
+* Input/output data via the tty, if available, instead of stdin/stdout.
+* Fixed possible crash when HOME variable is not set.
+* rnpkeys: Added `--import-sigs` and changed behavior of `--import` to check whether input is key or signature.
+* rnpkeys: Added `--export-rev` command to export key's revocation, parameters `--rev-type`, `--rev-reason`.
+* rnpkeys: Added `--revoke-key` command.
+* rnpkeys: Added `--permissive` parameter to `--import-keys` command.
+* rnpkeys: Added `--password` options, allowing to specify password and/or generate unprotected key.
+
+== FFI
+
+* Added keystore type constants `RNP_KEYSTORE_*`.
+* Added `rnp_import_signatures`.
+* Added `rnp_key_export_revocation`.
+* Added `rnp_key_revoke`.
+* Added `rnp_request_password`.
+* Added `rnp_key_set_expiration` to update key's/subkey's expiration time.
+* Added flag `RNP_LOAD_SAVE_PERMISSIVE` to `rnp_import_keys`, allowing to skip erroneous packets.
+* Added flag `RNP_LOAD_SAVE_SINGLE`, allowing to import keys one-by-one.
+* Added `rnp_op_verify_get_protection_info` to check mode and cipher used to encrypt message.
+* Added functions to retrieve recipients information (`rnp_op_verify_get_recipient_count`, `rnp_op_verify_get_symenc_count`, etc.).
+* Added flag `RNP_KEY_REMOVE_SUBKEYS` to `rnp_key_remove` function.
+* Added function `rnp_output_pipe` allowing to write data from input to the output.
+* Added function `rnp_output_armor_set_line_length` allowing to change base64 encoding line length.
+* Added function `rnp_key_export_autocrypt` to export public key in autocrypt-compatible format.
+* Added functions to retrieve information about the secret key's protection (`rnp_key_get_protection_type`, etc.).
+* Added functions `rnp_uid_get_type`, `rnp_uid_get_data`, `rnp_uid_is_primary`.
+* Added function `rnp_uid_is_valid`.
+* Added functions `rnp_key_get_revocation_signature` and `rnp_uid_get_revocation_signature`.
+* Added function `rnp_signature_get_type`.
+* Added function `rnp_signature_is_valid`.
+* Added functions `rnp_key_is_valid` and `rnp_key_valid_till`.
+* Added exception guard to FFI boundary.
+* Fixed documentation for the `rnp_unload_keys` function.
+
+== Security
+
+* Removed version header from armored messages (see footnote:[https://mailarchive.ietf.org/arch/msg/openpgp/KikdJaxvdulxIRX_yxU2_i3lQ7A/] ).
+* Enabled fuzzing via oss-fuzz and fixed reported issues.
+* Fixed a bunch of issues reported by static analyzer.
+* Require at least Botan 2.14.0.

--- a/_posts/2021-01-21-rnp-014-released.adoc
+++ b/_posts/2021-01-21-rnp-014-released.adoc
@@ -1,15 +1,17 @@
 ---
 layout: post
-title:  "RNP 0.14.0 has been released"
+title:  "RNP 0.14.0 released"
 date:   2021-01-21 21:05:38 +0700
 categories: release
 excerpt: >-
-  After a long delay the next version of the library and CLI was released. It a lot of major FFI, CLI and security improvements and compatibility fixes. Also now it can be built for Windows via MSVC and MinGW/MSYS2.
+  After a long delay the next version of the library and CLI was released. Major FFI, CLI and security improvements and compatibility fixes. Also now it can be built for Windows via MSVC and MinGW/MSYS2.
 redirect_from:
   - /blog/21-01-2021/rnp-014-released/
 ---
 
 == General
+
+After a long delay the next version of the library and CLI was released. Major FFI, CLI and security improvements and compatibility fixes. Also now it can be built for Windows via MSVC and MinGW/MSYS2.
 
 * Improved key validation: require to have at least one valid, non-expiring self signature.
 * Added support for 'stripped' keys without userids and certifications but with valid subkey binding signature.


### PR DESCRIPTION
This PR adds missing blog posts about the v0.11.0-v.0.14.0 releases.
Please help to check the language/wording, or suggest any ideas on shortened blog posts about the new release.

Fixes #18 
Fixes #25 